### PR TITLE
Version 0.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>es.um.dis.tecnomod</groupId>
 	<artifactId>ontology-shrink</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2-SNAPSHOT</version>
 	<properties>
 		<commons-cli.version>1.4</commons-cli.version>
 		<graphlib.version>0.0.3</graphlib.version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,5 +84,14 @@
 			<artifactId>commons-collections4</artifactId>
 			<version>${commons-collections4.version}</version>
 		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.9.1</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/src/main/java/es/um/dis/tecnomod/ontologyShrink/main/Main.java
+++ b/src/main/java/es/um/dis/tecnomod/ontologyShrink/main/Main.java
@@ -56,6 +56,7 @@ public class Main {
 		setLogLevel(cmd.getOptionValue('l', Level.INFO.getName()));
 		
 		File inputOWLFile = new File(cmd.getOptionValue('i'));
+		Optional prefix = Optional.ofNullable(cmd.getOptionValue('o'));
 		
 		if (!inputOWLFile.exists()) {
 			LOGGER.log(Level.SEVERE, String.format("'%s' not found.", args[0]));
@@ -104,8 +105,12 @@ public class Main {
 				LOGGER.log(Level.INFO, String.format("'%s' percent annotation additional reduction begins...", increaseReduction.toString()));
 				
 				if (inputOWLFile.isFile()) {
-					
-					String ouputFullName = inputOWLFile.getParent() + File.separatorChar + inputJustName +"_reduced_"+ String.format("%03d", hraReduction) +"." + inputExtension.get();
+					String ouputFullName;
+					if (prefix.isPresent()) {
+						ouputFullName = prefix.get() +"_"+ String.format("%d", hraReduction) +"." + inputExtension.get();
+					} else {
+						ouputFullName = inputOWLFile.getParent() + File.separatorChar + inputJustName +"_"+ String.format("%d", hraReduction) +"." + inputExtension.get();
+					}
 					
 					File outputOWLFile = new File(ouputFullName);
 					
@@ -170,6 +175,10 @@ public class Main {
         Option reduction = new Option("r", "HRA_reduction", true, "Percentage (int) list of human readable annotation reduction separated by ','");
         reduction.setRequired(true);
         options.addOption(reduction);
+        
+        Option prefix = new Option("o", "output_prefix", true, "Prefix used for saving the output owl files. For example, if prefix is GO and reductions are '20,40,60', output files will be GO_20.owl, GO_40.owl and GO_60.owl");
+        prefix.setRequired(false);
+        options.addOption(prefix);
         
         Option logLevel = new Option("l", "log-level", true, "log level (SEVERE|WARNING|INFO|CONFIG|FINE|FINER|FINEST|ALL )");
         logLevel.setRequired(false);

--- a/src/main/java/es/um/dis/tecnomod/ontologyShrink/services/OntologyUtils.java
+++ b/src/main/java/es/um/dis/tecnomod/ontologyShrink/services/OntologyUtils.java
@@ -1,12 +1,16 @@
 package es.um.dis.tecnomod.ontologyShrink.services;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.semanticweb.owlapi.model.AxiomType;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.util.OWLEntityRemover;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 
 import uk.ac.manchester.cs.owl.owlapi.OWLLiteralImplBoolean;
@@ -15,16 +19,17 @@ import uk.ac.manchester.cs.owl.owlapi.OWLLiteralImplBoolean;
  * The Class OntologyUtils.
  */
 public class OntologyUtils {
-	
+
 	/**
 	 * Checks if a class is obsolete or not.
 	 *
 	 * @param owlEntity the owl class
-	 * @param ontology the ontology
+	 * @param ontology  the ontology
 	 * @return true, if is obsolete
 	 */
 	public static boolean isObsolete(OWLEntity owlEntity, OWLOntology ontology) {
-		Set<OWLAnnotationAssertionAxiom> axioms = ontology.annotationAssertionAxioms(owlEntity.getIRI()).collect(Collectors.toSet());
+		Set<OWLAnnotationAssertionAxiom> axioms = ontology.annotationAssertionAxioms(owlEntity.getIRI())
+				.collect(Collectors.toSet());
 		for (OWLAnnotationAssertionAxiom axiom : axioms) {
 			IRI propertyIRI = axiom.getProperty().asOWLAnnotationProperty().getIRI();
 			if (propertyIRI.equals(OWLRDFVocabulary.OWL_DEPRECATED.getIRI())
@@ -38,23 +43,71 @@ public class OntologyUtils {
 		}
 		return false;
 	}
-	
+
 	/**
-	 * Gets all the annotations assertion axioms of one entity type from an ontology.   
+	 * Gets all the annotations assertion axioms of one entity type from an
+	 * ontology.
 	 * 
 	 * @param entity
 	 * @param ontology
 	 * @param includeImports
 	 * @return a set of OWLAnnotationAssertionAxiom
 	 */
-	public static Set<OWLAnnotationAssertionAxiom> getOWLAnnotationAssertionAxiom(OWLEntity entity, OWLOntology ontology, boolean includeImports) {
-		Set<OWLAnnotationAssertionAxiom> annotationAssertionAxioms = ontology.annotationAssertionAxioms(entity.getIRI()).collect(Collectors.toSet());
+	public static Set<OWLAnnotationAssertionAxiom> getOWLAnnotationAssertionAxiom(OWLEntity entity,
+			OWLOntology ontology, boolean includeImports) {
+		Set<OWLAnnotationAssertionAxiom> annotationAssertionAxioms = ontology.annotationAssertionAxioms(entity.getIRI())
+				.collect(Collectors.toSet());
 		if (includeImports) {
 			for (OWLOntology importedOntology : ontology.imports().collect(Collectors.toList())) {
-				Set<OWLAnnotationAssertionAxiom> importedAnnotationAssertionAxioms = importedOntology.annotationAssertionAxioms(entity.getIRI()).collect(Collectors.toSet());
+				Set<OWLAnnotationAssertionAxiom> importedAnnotationAssertionAxioms = importedOntology
+						.annotationAssertionAxioms(entity.getIRI()).collect(Collectors.toSet());
 				annotationAssertionAxioms.addAll(importedAnnotationAssertionAxioms);
 			}
 		}
 		return annotationAssertionAxioms;
+	}
+
+	public static void removeUnclassifiedAnnotations(OWLOntology ontology) {
+		List<OWLAxiom> axiomsToRemove = ontology.axioms().filter(x -> (x.isOfType(AxiomType.ANNOTATION_ASSERTION)))
+				.filter(annotationAssertion -> (!AnnotationsClustering.NAME_PROPERTIES
+						.contains(((OWLAnnotationAssertionAxiom) annotationAssertion).getProperty().getIRI())
+						&& !AnnotationsClustering.DESCRIPTION_PROPERTIES
+								.contains(((OWLAnnotationAssertionAxiom) annotationAssertion).getProperty().getIRI())
+						&& !AnnotationsClustering.SYNONYM_PROPERTIES
+								.contains(((OWLAnnotationAssertionAxiom) annotationAssertion).getProperty().getIRI()))).collect(Collectors.toList());
+		ontology.removeAxioms(axiomsToRemove);
+	}
+
+	public static void removeObsoloteEntities(OWLOntology ontology) {
+		OWLEntityRemover entityRemover = new OWLEntityRemover(ontology);
+		visitObsoleteClasses(ontology, entityRemover);
+		visitObsoleteObjectProperties(ontology, entityRemover);
+		visitObsoleteDataProperties(ontology, entityRemover);
+		visitObsoleteAnnotationProperties(ontology, entityRemover);
+		ontology.applyChanges(entityRemover.getChanges());
+	}
+
+	public static void visitObsoleteClasses(OWLOntology ontology, OWLEntityRemover entityRemover) {
+		ontology.classesInSignature().filter(x -> isObsolete(x, ontology)).forEach(x -> {
+			entityRemover.visit(x);
+		});
+	}
+
+	public static void visitObsoleteObjectProperties(OWLOntology ontology, OWLEntityRemover entityRemover) {
+		ontology.objectPropertiesInSignature().filter(x -> isObsolete(x, ontology)).forEach(x -> {
+			entityRemover.visit(x);
+		});
+	}
+
+	public static void visitObsoleteDataProperties(OWLOntology ontology, OWLEntityRemover entityRemover) {
+		ontology.dataPropertiesInSignature().filter(x -> isObsolete(x, ontology)).forEach(x -> {
+			entityRemover.visit(x);
+		});
+	}
+
+	public static void visitObsoleteAnnotationProperties(OWLOntology ontology, OWLEntityRemover entityRemover) {
+		ontology.annotationPropertiesInSignature().filter(x -> isObsolete(x, ontology)).forEach(x -> {
+			entityRemover.visit(x);
+		});
 	}
 }

--- a/src/test/java/es/um/dis/tecnomod/ontologyShrink/services/OntologyUtilsTest.java
+++ b/src/test/java/es/um/dis/tecnomod/ontologyShrink/services/OntologyUtilsTest.java
@@ -1,0 +1,39 @@
+package es.um.dis.tecnomod.ontologyShrink.services;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.OWLOntologyStorageException;
+
+class OntologyUtilsTest {
+
+	@Test
+	void testGO() throws OWLOntologyCreationException, OWLOntologyStorageException, FileNotFoundException {
+		OWLOntology ontology = OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(new File("/home/fabad/legibility_embeddings_clean/ontologies/go/go.owl"));
+		OntologyUtils.removeObsoloteEntities(ontology);
+		OntologyUtils.removeUnclassifiedAnnotations(ontology);
+		ontology.saveOntology(new FileOutputStream(new File("/home/fabad/legibility_embeddings_clean/ontologies/go/go_clean.owl")));
+	}
+
+	@Test
+	void testDTO() throws OWLOntologyCreationException, OWLOntologyStorageException, FileNotFoundException {
+		OWLOntology ontology = OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(new File("/home/fabad/legibility_embeddings_clean/ontologies/dto/dto.owl"));
+		OntologyUtils.removeObsoloteEntities(ontology);
+		OntologyUtils.removeUnclassifiedAnnotations(ontology);
+		ontology.saveOntology(new FileOutputStream(new File("/home/fabad/legibility_embeddings_clean/ontologies/dto/dto_clean.owl")));
+	}
+
+	@Test
+	void testSO() throws OWLOntologyCreationException, OWLOntologyStorageException, FileNotFoundException {
+		OWLOntology ontology = OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(new File("/home/fabad/legibility_embeddings_clean/ontologies/so/so.owl"));
+		OntologyUtils.removeObsoloteEntities(ontology);
+		OntologyUtils.removeUnclassifiedAnnotations(ontology);
+		ontology.saveOntology(new FileOutputStream(new File("/home/fabad/legibility_embeddings_clean/ontologies/so/so_clean.owl")));
+	}
+
+}

--- a/src/test/java/es/um/dis/tecnomod/ontologyShrink/services/OntologyUtilsTest.java
+++ b/src/test/java/es/um/dis/tecnomod/ontologyShrink/services/OntologyUtilsTest.java
@@ -35,5 +35,21 @@ class OntologyUtilsTest {
 		OntologyUtils.removeUnclassifiedAnnotations(ontology);
 		ontology.saveOntology(new FileOutputStream(new File("/home/fabad/legibility_embeddings_clean/ontologies/so/so_clean.owl")));
 	}
+	
+	@Test
+	void testHelis() throws OWLOntologyCreationException, OWLOntologyStorageException, FileNotFoundException {
+		OWLOntology ontology = OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(new File("/home/fabad/legibility_embeddings_clean/ontologies/helis/helis.owl"));
+		OntologyUtils.removeObsoloteEntities(ontology);
+		OntologyUtils.removeUnclassifiedAnnotations(ontology);
+		ontology.saveOntology(new FileOutputStream(new File("/home/fabad/legibility_embeddings_clean/ontologies/helis/helis_clean.owl")));
+	}
+	
+	@Test
+	void testFoodon() throws OWLOntologyCreationException, OWLOntologyStorageException, FileNotFoundException {
+		OWLOntology ontology = OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(new File("/home/fabad/legibility_embeddings_clean/ontologies/foodon/foodon.owl"));
+		OntologyUtils.removeObsoloteEntities(ontology);
+		OntologyUtils.removeUnclassifiedAnnotations(ontology);
+		ontology.saveOntology(new FileOutputStream(new File("/home/fabad/legibility_embeddings_clean/ontologies/foodon/foodon_clean.owl")));
+	}
 
 }


### PR DESCRIPTION
I've set the version 0.0.2. I've included a JUnit test to quickly generate the clean versions of the input ontologies (by removing deprecated entities and annotation assertion axioms using annotation properties not considered in legibility). I've restored the -o option to set a prefix for generating resulting owl files. This is useful when using the application in a script.